### PR TITLE
Update dimension for Amazon SageMaker search index.

### DIFF
--- a/docs/7-vector-search/6-create-index.mdx
+++ b/docs/7-vector-search/6-create-index.mdx
@@ -86,7 +86,7 @@ Select your database and collection, change the index name to `vectorsearch`, an
     "dynamic": true,
     "fields": {
       "vectorizedSynopsis": {
-        "dimensions": 1408,
+        "dimensions": 384,
         "similarity": "cosine",
         "type": "knnVector"
       }


### PR DESCRIPTION
The model we're using now offers 384 dimensions for the embeddings.