### PR TITLE
Fix embeddings field name

### DIFF
--- a/docs/7-vector-search/6-create-index.mdx
+++ b/docs/7-vector-search/6-create-index.mdx
@@ -31,7 +31,7 @@ Select your database and collection, change the index name to `vectorsearch`, an
   "mappings": {
     "dynamic": true,
     "fields": {
-      "vectorizedSynopsis": {
+      "embeddings": {
         "dimensions": 1408,
         "similarity": "cosine",
         "type": "knnVector"
@@ -49,7 +49,7 @@ Select your database and collection, change the index name to `vectorsearch`, an
   "mappings": {
     "dynamic": true,
     "fields": {
-      "vectorizedSynopsis": {
+      "embeddings": {
         "dimensions": 1536,
         "similarity": "cosine",
         "type": "knnVector"
@@ -67,7 +67,7 @@ Select your database and collection, change the index name to `vectorsearch`, an
   "mappings": {
     "dynamic": true,
     "fields": {
-      "vectorizedSynopsis": {
+      "embeddings": {
         "dimensions": 1408,
         "similarity": "cosine",
         "type": "knnVector"
@@ -85,7 +85,7 @@ Select your database and collection, change the index name to `vectorsearch`, an
   "mappings": {
     "dynamic": true,
     "fields": {
-      "vectorizedSynopsis": {
+      "embeddings": {
         "dimensions": 384,
         "similarity": "cosine",
         "type": "knnVector"


### PR DESCRIPTION
The embeddings field name in our source cluster in all vector collections (openai, sagemaker,...) is `embeddings`. The field name in the lab is `vectorizedSynopsis` which is incorrect.