### PR TITLE
fix: remove old screenshot

### DIFF
--- a/docs/7-vector-search/6-create-index.mdx
+++ b/docs/7-vector-search/6-create-index.mdx
@@ -98,11 +98,5 @@ Select your database and collection, change the index name to `vectorsearch`, an
   </TabItem>
 </Tabs>
 
-Your configuration should look like this.
-
-<Screenshot src="img/screenshots/7-vector-search/6-create-index/4-json-editor-config.png" alt="The 'JSON Editor' tab with the configuration highlighted" url="https://cloud.mongodb.com" />
-
-
-
 The final step allows you to review the index configuration and refine it if needed. Go ahead and click **Create Search Index**.
 


### PR DESCRIPTION
The screenshot is using an old field name which is no longer correct. It also has a fixed dimension of `1536` which can be misleading depending on the provider you're using.

Page: https://mongodb-developer.github.io/search-lab/docs/vector-search/create-index