### PR TITLE
fix typos

### DIFF
--- a/docs/1-full-text-search/2-why-search.mdx
+++ b/docs/1-full-text-search/2-why-search.mdx
@@ -8,7 +8,7 @@ If they can't find what they are looking for, they will leave your site and go s
 
 # Adding Search capabilities to your site
 
-Ther are many ways to add search capabilities to your site. One of the most popular way is to use an open source search engine like Elasticsearch or Solr. These search engines are very powerful and can be used to index and search millions of documents.
+There are many ways to add search capabilities to your site. One of the most popular ways is to use an open source search engine like Elasticsearch or Solr. These search engines are very powerful and can be used to index and search millions of documents.
 
 Behind the hood, both of these search engines use Lucene to index and search documents. Lucene is a Java library that provides a simple API for indexing and searching documents.
 

--- a/docs/2-search/2-search-index.mdx
+++ b/docs/2-search/2-search-index.mdx
@@ -1,6 +1,6 @@
 # 👐 Create an Atlas Search index
 
-To start using Atlas Search, you must configure a search index on your database. Atlas Search indexes categorize data in an easily searchable format and enable faster document retrieval using certain identifiers. You can create a search index right from the Atlas UI.
+To start using Atlas Search, you must configure a search index on your database. Atlas Search indexes categorized data in an easily searchable format and enable faster document retrieval using certain identifiers. You can create a search index right from the Atlas UI.
 
 ## Step-by-step guide to creating your first Atlas Search index
 

--- a/docs/2-search/3-test-search.mdx
+++ b/docs/2-search/3-test-search.mdx
@@ -37,7 +37,7 @@ This will open up the query editor.
 
 <Screenshot src="img/screenshots/2-search/3-test-search/3-query-editor.png" alt="The Edit $search query button" url="https://cloud.mongodb.com" />
 
-Notice you the `path` property currently shows `*`. This means that it will search the entire document. Try to change the search to only search the `title` field.
+Notice that the `path` property currently shows `*`. This means that it will search the entire document. Try to change the search to only search the `title` field.
 
 :::tip
 You can find more information about how to construct a query path in the [Search documentation](https://www.mongodb.com/docs/atlas/atlas-search/path-construction/).

--- a/docs/3-aggregations/1-search-stage.mdx
+++ b/docs/3-aggregations/1-search-stage.mdx
@@ -12,12 +12,12 @@ In this section, we'll build an aggregation pipeline with the `$search` stage wh
 
 ## Aggregations in the Atlas UI
 
-Navigate to the **Collections** tab of your database deployment, pick the `books` collection, andn avigate to the **Aggregation** tab from the navbar under your collection details.
+Navigate to the **Collections** tab of your database deployment, pick the `books` collection, and navigate to the **Aggregation** tab from the navbar under your collection details.
 
 <Screenshot alt="Aggregations tab highlighted on the collection details page" src="img/screenshots/3-aggregations/1-search-stage/1-aggregation-tab.png" url="https://cloud.mongodb.com" />
 
 :::tip
-The Atlas UI can start feeling a bit cramp at this point. You can also use the aggregation pipeline builder in <Link to="https://www.mongodb.com/products/tools/compass">Compass</Link> for a better experience.
+The Atlas UI can start feeling a bit cramped at this point. You can also use the aggregation pipeline builder in <Link to="https://www.mongodb.com/products/tools/compass">Compass</Link> for a better experience.
 :::
 
 Click the **Add Stage** button and type **$search** in the **select** input.

--- a/docs/5-search-operators/02-text.mdx
+++ b/docs/5-search-operators/02-text.mdx
@@ -1,6 +1,6 @@
 # 📘 The `text` operator
 
-The `text` operator is used to performs a full-text search using the analyzer that you specify in the index configuration. It is used to search for words or phrases in the full-text fields of your documents.
+The `text` operator is used to perform a full-text search using the analyzer that you specify in the index configuration. It is used to search for words or phrases in the full-text fields of your documents.
 
 The `text` operator uses the `OR` operator to combine the search terms. For example, if you search for `Joy of Cooking`, the search will return all documents that contain either `Joy`, `of`, `Cooking` or a combination of those.
 

--- a/docs/7-vector-search/5-create-vectors/3-openai.mdx
+++ b/docs/7-vector-search/5-create-vectors/3-openai.mdx
@@ -22,7 +22,7 @@ From there, click on the **Create new secret key** button.
 
 <Screenshot src="img/screenshots/7-vector-search/5-create-vectors/3-openai/2-create-key.png" url="https://platform.openai.com/account/api-keys" alt="The OpenAI API keys page" />
 
-You'll be prompted to give you key a name. You can call it "MongoDB Vector Search Demo". Then click on the **Create secret key** button.
+You'll be prompted to give your key a name. You can call it "MongoDB Vector Search Demo". Then click on the **Create secret key** button.
 
 You will then be presented with your API key. Copy it and save it somewhere safe.
 

--- a/docs/7-vector-search/9-filtering.mdx
+++ b/docs/7-vector-search/9-filtering.mdx
@@ -4,7 +4,7 @@
 Extra activity, do it if you have extra time or are following at home, won't be covered during the hands-on Lab.
 :::
 
-One of the nice things about Vector Search in Atlas is its seamless integration with the MongDB ecosystem. For instance, to do a vector search we use an Aggregation Pipeline stage, and after searching we can project, limit our data, etc. But sometimes we want to filter _before_ running the semantic search. For that, we can use the optinal `filter` property in `$vectorSearch`.
+One of the nice things about Vector Search in Atlas is its seamless integration with the MongDB ecosystem. For instance, to do a vector search we use an Aggregation Pipeline stage, and after searching we can project, limit our data, etc. But sometimes we want to filter _before_ running the semantic search. For that, we can use the optional `filter` property in `$vectorSearch`.
 
 ## Pre-filtering using number fields
 


### PR DESCRIPTION
This PR fixes a few typos in:
- 2-search-index.mdx
- 3-test-search.mdx
- 2-why-search.mdx
- 1-search-stage.mdx
- 3-openai.mdx
- 9-filtering.mdx
- 02-text.mdx