### PR TITLE
Added a link to the Sagemaker post

### DIFF
--- a/docs/7-vector-search/5-create-vectors/3-ws-sagemaker.mdx
+++ b/docs/7-vector-search/5-create-vectors/3-ws-sagemaker.mdx
@@ -1,0 +1,13 @@
+# 🦸 Using Amazon SageMaker
+
+:::info
+Extra activity, do it if you have extra time or are following at home, won't be covered during the hands-on Lab.
+:::
+
+[Amazon SageMaker](https://aws.amazon.com/pm/sagemaker/) is a cloud-based, machine-learning platform that enables developers to build, train, and deploy machine learning (ML) models for any use case with fully managed infrastructure, tools, and workflows.
+
+## Getting Started With Amazon SageMaker
+
+Just follow the steps in part 2 of [this tutorial](https://www.mongodb.com/developer/products/atlas/amazon-sagemaker-and-mongodb-vector-search-part-1/), adapting it to the library information we've been using.
+
+- [Create Your Model Endpoint With Amazon SageMaker, AWS Lambda, and AWS API Gateway](https://www.mongodb.com/developer/products/atlas/amazon-sagemaker-and-mongodb-vector-search-part-2/)


### PR DESCRIPTION
Instead of maintaining here a separate set of instructions for Sagemaker, we're pointing to the blog post so we just maintain that.