### PR TITLE
Remove obsolete options for embeddings and API key

### DIFF
--- a/docs/7-vector-search/4-import-data.mdx
+++ b/docs/7-vector-search/4-import-data.mdx
@@ -2,30 +2,13 @@
 
 In the context of this workshop, you might not have enough time to [vectorize your own data](/docs/category/-create-vectors). Therefore, we have provided a vectorized version of the data for you to use.
 
-The data has been pre-encoded using various providers, so you can use the one that you are most comfortable with.
-
-Keep in mind that your queries will need to be encoded with the same provider as the data.
-
-The model that was used for each data set is listed below:
-
-| Data Set | Model | Documentation |
-| -------- | ----- | ------------- |
-| Google Cloud Vertex AI | multimodalembedding@001 | [Docs](https://cloud.google.com/vertex-ai/docs/generative-ai/embeddings/get-multimodal-embeddings) |
-| OpenAI | text-embedding-ada-002 | [Docs](https://platform.openai.com/docs/guides/embeddings) |
+The data has been pre-encoded using the [`multimodalembedding@001` model](https://cloud.google.com/vertex-ai/docs/generative-ai/embeddings/get-multimodal-embeddings) from Google Cloud Vertex AI. Keep in mind that your queries will be encoded with the same provider as the data.
 
 ## Import the embeddings
 
 To import the dataset with the pre-created embeddings, you can use the [import tool](https://mdb.link/import-library-data) that you used earlier.
 
-Enter your connection string in the text box at the top, and pick your provider from the dropdown at the bottom of the screen.
-
-<Screenshot src="/img/screenshots/7-vector-search/4-import-data/1-import.png" url="https://mdb.link/import-library-data" />
-
-:::tip
-If unsure, or don't want to create your own embeddings, you can use the `Serverless Endpoint` provider.
-:::
-
-Once you've picked your provider, click on the `Add Embeddings` button.
+Enter your connection string in the text box at the top and click **Add Embeddings**.
 
 :::warning
 This process will drop your existing `books` collection to replace it with a new one. Any existing indexes or changes to your collection will be lost.

--- a/docs/7-vector-search/6-create-index.mdx
+++ b/docs/7-vector-search/6-create-index.mdx
@@ -1,5 +1,3 @@
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 import Screenshot from "../../src/components/Screenshot";
 
 # 👐 Create Vector Search Indexes
@@ -23,9 +21,6 @@ This time, you will use the **JSON Editor** to create your index, select that op
 
 Add the following code in the JSON editor:
 
-<Tabs groupId="aiproviders">
-  <TabItem value="serverless" label="Serverless Endpoint" default>
-
 ```js
 {
   "fields":[
@@ -38,40 +33,5 @@ Add the following code in the JSON editor:
   ]
 }
 ```
-
-  </TabItem>
-  <TabItem value="openai" label="OpenAI" default>
-
-```js
-{
-  "fields":[
-    {
-      "type": "vector",
-      "path": "embeddings",
-      "numDimensions": 1536,
-      "similarity": "cosine"
-    }
-  ]
-}
-```
-
-  </TabItem>
-  <TabItem value="googleVertex" label="Google Cloud Vertex AI">
-
-```js
-{
-  "fields":[
-    {
-      "type": "vector",
-      "path": "embeddings",
-      "numDimensions": 1408,
-      "similarity": "cosine"
-    }
-  ]
-}
-```
-
-  </TabItem>
-</Tabs>
 
 The final step allows you to review the index configuration and refine it, if needed. Go ahead and click **Create Vector Search Index**.

--- a/docs/7-vector-search/8-add-to-app.mdx
+++ b/docs/7-vector-search/8-add-to-app.mdx
@@ -1,26 +1,10 @@
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 # 👐 Add Semantic Search to Your Application
 
 You now know everything you need to add vector search capabilities to your application.
 
-## Configuring the environment variables
-
-In your `server/.env` [file](https://github.com/mongodb-developer/library-management-system/blob/main/server/.env), you'll find a few variables that you can use to configure the application. Add a couple more at the end of the file to configure the embeddings source and the API key.
-
-```json
-EMBEDDINGS_SOURCE=serverlessEndpoint
-EMBEDDING_KEY=<API Key>
-```
-
-:::tip
-Your instructor will provide you with an API key that you can use for the event you're attending. Set it in the `EMBEDDING_KEY` variable.
-:::
-
 ## Configuring the vector search query
 
-Open up the code from the server [file](https://github.com/mongodb-developer/library-management-system/blob/main/server/src/controllers/books.ts) `server/src/controllers/books.ts` once more, and edit the `searchBooks` method to query your data for semantic search.
+Open up the `BookController` in **server/src/controllers/books.ts** once more, and edit the `searchBooks` method to query your data for semantic search.
 
 :::tip
 Use the `getEmbeddings` function to convert the query into a vector.

--- a/i18n/zh/docusaurus-plugin-content-docs/current/7-vector-search/6-create-index.mdx
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/7-vector-search/6-create-index.mdx
@@ -2,9 +2,6 @@
 sidebar_position: 76
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 # 👐 创建向量搜索索引
 
 要开始使用向量搜索，你必须在数据库上配置另一个搜索索引。这个过程与上一节中所做的类似。
@@ -25,9 +22,6 @@ import TabItem from '@theme/TabItem';
 
 选择你的数据库和 `books` 集合，将索引名称更改为 `vectorsearch`，并在 JSON 编辑器中添加以下代码：
 
-<Tabs groupId="aiproviders">
-  <TabItem value="serverless" label="Serverless Endpoint" default>
-
 ```js
 {
   "fields":[
@@ -40,40 +34,5 @@ import TabItem from '@theme/TabItem';
   ]
 }
 ```
-
-  </TabItem>
-  <TabItem value="openai" label="OpenAI" default>
-
-```js
-{
-  "fields":[
-    {
-      "type": "vector",
-      "path": "embeddings",
-      "numDimensions": 1536,
-      "similarity": "cosine"
-    }
-  ]
-}
-```
-
-  </TabItem>
-  <TabItem value="googleVertex" label="Google Cloud Vertex AI">
-
-```js
-{
-  "fields":[
-    {
-      "type": "vector",
-      "path": "embeddings",
-      "numDimensions": 1408,
-      "similarity": "cosine"
-    }
-  ]
-}
-```
-
-  </TabItem>
-</Tabs>
 
 最后一步允许你查看索引配置并在需要时进行优化。继续点击 **Create Search Index**。

--- a/i18n/zh/docusaurus-plugin-content-docs/current/7-vector-search/8-add-to-app.mdx
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/7-vector-search/8-add-to-app.mdx
@@ -2,25 +2,9 @@
 sidebar_position: 78
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 # 👐 将语义搜索添加到您的应用程序
 
 您现在知道了将向量搜索功能添加到应用程序所需的一切。
-
-## 配置环境变量
-
-在您的 `server/.env` [文件](https://github.com/mongodb-developer/library-management-system/blob/main/server/.env)中，您会发现一些可以用来配置应用程序的变量。在文件末尾添加几个变量，以配置嵌入源和 API 密钥。
-
-```json
-EMBEDDINGS_SOURCE=serverlessEndpoint
-EMBEDDING_KEY=<API Key>
-```
-
-:::tip
-您的导师将为您提供一个 API 密钥，您可以在参加的活动中使用。将其设置在 `EMBEDDING_KEY` 变量中。
-:::
 
 ## 配置向量搜索查询
 


### PR DESCRIPTION
This PR removes:

- Obsolete embedding options that are no longer in the import app.
- Obsolete API key configuration that is no longer needed.