### PR TITLE
Fix broken image reference after atlas-search.png rename

### DIFF
--- a/docs/1-full-text-search/3-why-MongoDB-search.mdx
+++ b/docs/1-full-text-search/3-why-MongoDB-search.mdx
@@ -2,7 +2,7 @@
 
 MongoDB Search is the built-in search solution for MongoDB. It is based on Apache Lucene and supports the Apache Lucene Query Parser Syntax. It supports text search, geospatial search, and faceted search.
 
-![MongoDB Search](/img/1-full-text-search/2-atlas-search.png)
+![MongoDB Search](/img/1-full-text-search/2-MongoDB-search.png)
 
 Using MongoDB Search, there is no need to sync the data between MongoDB and a third-party tool. It is built on top of the MongoDB query engine, so it is always up to date with the latest MongoDB features and allows you to use the MongoDB query language to search your data.
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/1-full-text-search/3-why-MongoDB-search.mdx
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/1-full-text-search/3-why-MongoDB-search.mdx
@@ -2,7 +2,7 @@
 
 MongoDB Search 是 MongoDB 的内置搜索解决方案。它是一种完全托管的服务，易于设置、操作和扩展。MongoDB Search 基于 Apache Lucene，并支持 Apache Lucene 查询解析器语法。它支持文本搜索、地理位置搜索和分面（facet）搜索。
 
-![MongoDB Search](/img/1-full-text-search/2-atlas-search.png)
+![MongoDB Search](/img/1-full-text-search/2-MongoDB-search.png)
 
 使用 MongoDB Search，无需在 MongoDB 和第三方工具之间同步数据。MongoDB Search 是一种完全托管的服务，易于设置、操作和扩展。它建立在 MongoDB 查询引擎之上，因此始终与最新的 MongoDB 功能保持同步，并允许你使用 MongoDB 查询语言来搜索数据。
 


### PR DESCRIPTION
## Summary

- Update `2-atlas-search.png` → `2-MongoDB-search.png` image reference in `3-why-MongoDB-search.mdx` (EN and ZH)
- The image file was renamed in a prior commit but the MDX reference wasn't updated, causing a build failure

Fixes MDX compilation error:
```
Image static/img/1-full-text-search/2-atlas-search.png used in docs/1-full-text-search/3-why-MongoDB-search.mdx not found.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)